### PR TITLE
Use x-mock-response-id

### DIFF
--- a/lib-core/src/main/java/com/steamclock/steamock/lib/PostmanMockConfig.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/PostmanMockConfig.kt
@@ -2,6 +2,16 @@ package com.steamclock.steamock.lib
 
 import kotlinx.serialization.json.Json
 
+
+// https://learning.postman.com/docs/designing-and-developing-your-api/mocking-data/mock-with-api/
+// todo investigate
+// - x-mock-response-code header
+// - x-mock-response-name or x-mock-response-id to specify the exact response you want the mock server to return
+
+
+// https://learning.postman.com/docs/designing-and-developing-your-api/mocking-data/creating-dynamic-responses/
+// - pulling out post path parameters
+
 data class PostmanMockConfig(
     val postmanAccessKey: String,
     val mockCollectionId: String,

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/repo/MockResponse.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/repo/MockResponse.kt
@@ -2,5 +2,5 @@ package com.steamclock.steamock.lib.repo
 
 sealed class MockResponse {
     class NoneAvailable(val hadError: Exception?): MockResponse()
-    class HasMockUrl(val mockUrl: String): MockResponse()
+    class HasMockUrl(val mockId: String, val mockUrl: String): MockResponse()
 }

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
@@ -113,7 +113,7 @@ class PostmanMockRepo(
             } ?: return MockResponse.NoneAvailable(hadError = null)
 
             // Pass back the mocking server URL we should use in place
-            MockResponse.HasMockUrl(getMockedUrl(mock))
+            MockResponse.HasMockUrl(mock.id, getMockedUrl(mock))
         } catch (e: Exception) {
             MockResponse.NoneAvailable(hadError = e)
         }

--- a/lib-ktor/src/main/java/com/steamclock/steamock/lib_ktor/PostmanMockInterceptorKtor.kt
+++ b/lib-ktor/src/main/java/com/steamclock/steamock/lib_ktor/PostmanMockInterceptorKtor.kt
@@ -25,7 +25,6 @@ class PostmanMockInterceptorKtor(
     override fun prepare(block: Unit.() -> Unit): PostmanMockInterceptorKtor = this
 
     override fun install(feature: PostmanMockInterceptorKtor, scope: HttpClient) {
-
         scope.requestPipeline.intercept(HttpRequestPipeline.Before) {
             when (val mockResponse = postmanMockRepo.getMockForPath(context.url.encodedPath)) {
                 is MockResponse.NoneAvailable -> {
@@ -40,6 +39,8 @@ class PostmanMockInterceptorKtor(
                 }
                 is MockResponse.HasMockUrl -> {
                     try {
+                        context.header("x-mock-response-id", mockResponse.mockId)
+
                         // Add delay header if desired
                         if (postmanMockRepo.mockResponseDelayMs > 0) {
                             Log.d("MockingRequestInterceptor", "x-mock-response-delay: ${postmanMockRepo.mockResponseDelayMs}ms")


### PR DESCRIPTION
Previously I had been relying on Postman's default matching algorithm to select a mock; this meant that if I had multiple mocks for the same API, I had to manually set unique path properties in Postman to allow them to be kept separate.

I found the [`x-mock-response-id` property  ](https://learning.postman.com/docs/designing-and-developing-your-api/mocking-data/matching-algorithm/) which I can use instead, thus removing the need for the Postman admin to do anything special to the mocked URL path.