### PR TITLE
Attempting setup for multi-module Jitpack support

### DIFF
--- a/app/src/main/java/com/steamclock/steamock/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamock/MainActivity.kt
@@ -47,9 +47,9 @@ class MainActivity : ComponentActivity() {
     // be setup via dependency injection.
     //=================================================================
     private val postmanConfig = PostmanMockConfig(
-        postmanAccessKey = com.steamclock.steamock.lib.BuildConfig.postmanAccessKey,
-        mockCollectionId = com.steamclock.steamock.lib.BuildConfig.postmanMockCollectionId,
-        mockServerUrl = com.steamclock.steamock.lib.BuildConfig.postmanMockServerUrl,
+        postmanAccessKey = com.steamclock.steamock.lib_core.BuildConfig.postmanAccessKey,
+        mockCollectionId = com.steamclock.steamock.lib_core.BuildConfig.postmanMockCollectionId,
+        mockServerUrl = com.steamclock.steamock.lib_core.BuildConfig.postmanMockServerUrl,
         json = appJson,
         logCalls = true
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
     id("com.android.library") version "8.1.1" apply false
+    id("org.jetbrains.kotlin.jvm") version "1.9.0"
+}
+
+subprojects {
+    /**
+     * Setup maven-publish on all modules; see each module for publication details.
+     */
+    apply(plugin = "maven-publish")
 }

--- a/lib-core/build.gradle.kts
+++ b/lib-core/build.gradle.kts
@@ -6,8 +6,31 @@ plugins {
     kotlin("plugin.serialization") version "1.9.21"
 }
 
+//============================================================
+// Maven/Jitpack Publishing
+//============================================================
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    from(android.sourceSets.getByName("main").java.srcDirs)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            val release by publications.registering(MavenPublication::class) {
+                from(components["release"])
+                artifact(sourcesJar.get())
+                artifactId = "lib-core"
+                groupId = "com.github.steamclock.steamock-android"
+                version = "1.0"
+            }
+        }
+    }
+}
+//============================================================
+
 android {
-    namespace = "com.steamclock.steamock.lib"
+    namespace = "com.steamclock.steamock.lib_core"
     compileSdk = 34
 
     // Postman mocking setup pulled from local.properties

--- a/lib-ktor/build.gradle.kts
+++ b/lib-ktor/build.gradle.kts
@@ -3,6 +3,29 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+//============================================================
+// Maven/Jitpack Publishing
+//============================================================
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    from(android.sourceSets.getByName("main").java.srcDirs)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            val release by publications.registering(MavenPublication::class) {
+                from(components["release"])
+                artifact(sourcesJar.get())
+                artifactId = "lib-ktor"
+                groupId = "com.github.steamclock.steamock-android"
+                version = "1.0"
+            }
+        }
+    }
+}
+//============================================================
+
 android {
     namespace = "com.steamclock.steamock.lib_ktor"
     compileSdk = 33

--- a/lib-retrofit/build.gradle.kts
+++ b/lib-retrofit/build.gradle.kts
@@ -3,6 +3,29 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+//============================================================
+// Maven/Jitpack Publishing
+//============================================================
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    from(android.sourceSets.getByName("main").java.srcDirs)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            val release by publications.registering(MavenPublication::class) {
+                from(components["release"])
+                artifact(sourcesJar.get())
+                artifactId = "lib-retrofit"
+                groupId = "com.github.steamclock.steamock-android"
+                version = "1.0"
+            }
+        }
+    }
+}
+//============================================================
+
 android {
     namespace = "com.steamclock.steamock.lib_retrofit"
     compileSdk = 33

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io" ) }
     }
 }
 


### PR DESCRIPTION
Issue: #5 

Attempting to setup gradle files to allow Jitpack to host our core and network modules separately; had some complications getting this to actually build with kotlin DSL, but I can't actually test until this is merged and a release is cut.