### PR TITLE
Jipack setup, part 2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.application") version "8.1.1" apply false
     id("com.android.library") version "8.1.1" apply false
     id("org.jetbrains.kotlin.jvm") version "1.9.0"
+    `maven-publish`
 }
 
 subprojects {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# configuration file for building snapshots and releases with jitpack.io
+jdk:
+  - openjdk11

--- a/lib-core/build.gradle.kts
+++ b/lib-core/build.gradle.kts
@@ -9,9 +9,13 @@ plugins {
 //============================================================
 // Maven/Jitpack Publishing
 //============================================================
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
+android {
+    publishing {
+        singleVariant("release") {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
 }
 
 afterEvaluate {
@@ -19,7 +23,6 @@ afterEvaluate {
         publications {
             val release by publications.registering(MavenPublication::class) {
                 from(components["release"])
-                artifact(sourcesJar.get())
                 artifactId = "lib-core"
                 groupId = "com.github.steamclock.steamock-android"
                 version = "1.0"

--- a/lib-ktor/build.gradle.kts
+++ b/lib-ktor/build.gradle.kts
@@ -6,17 +6,21 @@ plugins {
 //============================================================
 // Maven/Jitpack Publishing
 //============================================================
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
+android {
+    publishing {
+        singleVariant("release") {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
 }
+
 
 afterEvaluate {
     publishing {
         publications {
             val release by publications.registering(MavenPublication::class) {
                 from(components["release"])
-                artifact(sourcesJar.get())
                 artifactId = "lib-ktor"
                 groupId = "com.github.steamclock.steamock-android"
                 version = "1.0"

--- a/lib-retrofit/build.gradle.kts
+++ b/lib-retrofit/build.gradle.kts
@@ -6,9 +6,13 @@ plugins {
 //============================================================
 // Maven/Jitpack Publishing
 //============================================================
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
+android {
+    publishing {
+        singleVariant("release") {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
 }
 
 afterEvaluate {
@@ -16,7 +20,6 @@ afterEvaluate {
         publications {
             val release by publications.registering(MavenPublication::class) {
                 from(components["release"])
-                artifact(sourcesJar.get())
                 artifactId = "lib-retrofit"
                 groupId = "com.github.steamclock.steamock-android"
                 version = "1.0"


### PR DESCRIPTION
First attempt resulted in the following error log on Jitpack:

```
Build starting...
Start: Fri Jan 26 20:55:34 UTC 2024 9893f2264ccb
Git:
v1.0-alpha-0-g6776305
commit 6776305fea757da683148836f13de68a3701f58e
Author: Shayla Sawchenko 
Date:   Fri Jan 26 12:34:25 2024 -0800

    Use x-mock-response-id so that admin does not have to make each mock have a unique path (#3)


Init SDKMan
Found Android manifest
Android SDK version: . Build tools: 
Found gradle
Gradle build script
Found gradle version: 8.0.
Using gradle wrapper
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Downloading https://services.gradle.org/distributions/gradle-8.0-bin.zip
.10%.20%.30%.40%.50%.60%.70%.80%.90%.100%

------------------------------------------------------------
Gradle 8.0
------------------------------------------------------------

Build time:   2023-02-13 13:15:21 UTC
Revision:     62ab9b7c7f884426cf79fbedcf07658b2dbe9e97

Kotlin:       1.8.10
Groovy:       3.0.13
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          1.8.0_292 (Private Build 25.292-b10)
OS:           Linux 4.18.0-25-generic amd64

0m3.619s
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~16.04.1-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
Getting tasks: ./gradlew tasks --all
Tasks: 

 ⚠️   WARNING:
 Gradle 'publishToMavenLocal' task not found. Please add the 'maven-publish' or 'maven' plugin.
 See the documentation and examples: https://docs.jitpack.io

Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'Steamock'.
> Could not resolve all files for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.1.1.
     Required by:
         project : > com.android.application:com.android.application.gradle.plugin:8.1.1
         project : > com.android.library:com.android.library.gradle.plugin:8.1.1
      > No matching variant of com.android.tools.build:gradle:8.1.1 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0' but:
          - Variant 'apiElements' capability com.android.tools.build:gradle:8.1.1 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'javadocElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'runtimeElements' capability com.android.tools.build:gradle:8.1.1 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'sourcesElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
Running: ./gradlew -Pgroup=com.github.steamclock -Pversion=v1.0-alpha publishToMavenLocal
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'Steamock'.
> Could not resolve all files for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.1.1.
     Required by:
         project : > com.android.application:com.android.application.gradle.plugin:8.1.1
         project : > com.android.library:com.android.library.gradle.plugin:8.1.1
      > No matching variant of com.android.tools.build:gradle:8.1.1 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0' but:
          - Variant 'apiElements' capability com.android.tools.build:gradle:8.1.1 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'javadocElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'runtimeElements' capability com.android.tools.build:gradle:8.1.1 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'sourcesElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 557ms
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'Steamock'.
> Could not resolve all files for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.1.1.
     Required by:
         project : > com.android.application:com.android.application.gradle.plugin:8.1.1
         project : > com.android.library:com.android.library.gradle.plugin:8.1.1
      > No matching variant of com.android.tools.build:gradle:8.1.1 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0' but:
          - Variant 'apiElements' capability com.android.tools.build:gradle:8.1.1 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'javadocElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'runtimeElements' capability com.android.tools.build:gradle:8.1.1 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')
          - Variant 'sourcesElements' capability com.android.tools.build:gradle:8.1.1 declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.0')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 698ms
Build tool exit code: 0
Looking for artifacts...
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Looking for pom.xml in build directory and ~/.m2
2024-01-26T20:56:25.890940855Z
Exit code: 0

⚠️ ERROR: No build artifacts found
```

I can't seem to documentation for my gradle 8 / kotlin DSL setup that works, so these changes came from me searching for the errors found and then applying changes until my local `./gradlew publishToMavenLocal` call succeeded.