### PR TITLE
UX cleanup

### DIFF
--- a/app/src/main/java/com/steamclock/steamock/ExampleApiRepo.kt
+++ b/app/src/main/java/com/steamclock/steamock/ExampleApiRepo.kt
@@ -11,6 +11,7 @@ class ExampleApiRepo(
 ) {
     private val mutableApiResponse = MutableStateFlow("")
     val apiResponse = mutableApiResponse.asStateFlow()
+    fun clearLastResponse() { mutableApiResponse.value = "" }
 
     suspend fun makeRequest(fullUrl: String) {
         mutableApiResponse.emit("Loading...")

--- a/app/src/main/java/com/steamclock/steamock/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamock/MainActivity.kt
@@ -118,52 +118,41 @@ class MainActivity : ComponentActivity() {
                 color = MaterialTheme.colors.background
             ) {
                 Column {
-                    when (mockCollectionState) {
-                        is ContentLoadViewState.Error,
-                        is ContentLoadViewState.Loading -> {
-                            stateText?.let {
-                                Text(modifier = Modifier.padding(16.dp), text = stateText)
-                                Spacer(modifier = Modifier.height(16.dp))
-                            }
-                        }
+                    // Input to allow us to test the interception
+                    Column(
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .wrapContentSize()
+                    ) {
+                        Text(
+                            text = "Request Simulator",
+                            style = MaterialTheme.typography.h6
+                        )
 
-                        is ContentLoadViewState.Success -> {
-                            // Input to allow us to test the interception
-                            Column(
-                                modifier = Modifier
-                                    .padding(16.dp)
-                                    .wrapContentSize()
-                            ) {
-                                Text(
-                                    text = "Request Simulator",
-                                    style = MaterialTheme.typography.h6
-                                )
+                        OutlinedTextField(
+                            value = exampleAPIUrl,
+                            onValueChange = { exampleAPIUrl = it }
+                        )
 
-                                OutlinedTextField(
-                                    value = exampleAPIUrl,
-                                    onValueChange = { exampleAPIUrl = it }
-                                )
-
-                                Button(
-                                    onClick = {
-                                        coroutineScope.launch {
-                                            exampleApiRepo.makeRequest(exampleAPIUrl)
-                                        }
-                                    }
-                                ) {
-                                    Text(text = "Send Request")
+                        Button(
+                            onClick = {
+                                coroutineScope.launch {
+                                    exampleApiRepo.makeRequest(exampleAPIUrl)
                                 }
                             }
-
-                            // Available mocks takes up the rest of the page
-                            Box(modifier = Modifier
-                                .weight(1f)
-                                .border(4.dp, MaterialTheme.colors.primary)) {
-                                AvailableMocks(
-                                    mockRepo = postmanRepo
-                                )
-                            }
+                        ) {
+                            Text(text = "Send Request")
                         }
+                    }
+
+                    // Available mocks takes up the rest of the page
+                    Box(modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .border(4.dp, MaterialTheme.colors.primary)) {
+                        AvailableMocks(
+                            mockRepo = postmanRepo
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/steamclock/steamock/MainActivity.kt
+++ b/app/src/main/java/com/steamclock/steamock/MainActivity.kt
@@ -86,16 +86,9 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val coroutineScope = rememberCoroutineScope()
-            val mockCollectionState by postmanRepo.mockCollectionState.collectAsState()
             val exampleAPIResponse by exampleApiRepo.apiResponse.collectAsState()
             var exampleAPIUrl by remember { mutableStateOf(BuildConfig.exampleDefaultUrl) }
             var openAlertDialog by remember { mutableStateOf(true) }
-
-            val stateText = when (val immutableState = mockCollectionState) {
-                is ContentLoadViewState.Error -> immutableState.throwable.localizedMessage
-                ContentLoadViewState.Loading -> "Fetching available Postman mocks..."
-                else -> null
-            }
 
             if (openAlertDialog) {
                 WelcomeDialog { openAlertDialog = false }
@@ -106,10 +99,6 @@ class MainActivity : ComponentActivity() {
                     text = exampleAPIResponse,
                     onDismiss = { exampleApiRepo.clearLastResponse() }
                 )
-            }
-
-            LaunchedEffect(Unit) {
-                postmanRepo.requestCollectionUpdate()
             }
 
             // A surface container using the 'background' color from the theme

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/api/PostmanAPIClient.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/api/PostmanAPIClient.kt
@@ -28,6 +28,7 @@ class PostmanAPIClient(
     private val postmanAPIBaseUrl = "https://api.getpostman.com"
     private val postmanAPICollectionPath = "collections"
 
+    @Throws(Exception::class)
     suspend fun getCollection(collectionId: String): Postman.CollectionResponse? {
         val collectionUrl = "$postmanAPIBaseUrl/$postmanAPICollectionPath/$collectionId"
         val request = Request.Builder()
@@ -38,17 +39,13 @@ class PostmanAPIClient(
         val response = client.newCall(request).executeAsync()
         return if (response.isSuccessful) {
             val responseBody = response.body.string()
-            try {
-                json.decodeFromString<Postman.CollectionResponse>(responseBody)
-            } catch (e: Exception) {
-                // todo Handle the error response
-                println("Error:  ${e.message}")
-                null
-            }
+            // Don't catch exceptions here, let them bubble up
+            json.decodeFromString<Postman.CollectionResponse>(responseBody)
         } else {
-            // todo Handle the error response
-            println("Error: ${response.code} - ${response.message}")
-            null
+            when(response.code) {
+                401 -> throw(Exception("Error: Unauthorized - Check your Postman API key"))
+                else -> throw(Exception("Error: ${response.code} - ${response.message}"))
+            }
         }
     }
 }

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/api/PostmanAPIClient.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/api/PostmanAPIClient.kt
@@ -11,7 +11,7 @@ import okhttp3.executeAsync
  * eventually mocking) data
  */
 class PostmanAPIClient(
-    private val config: PostmanMockConfig
+    private var config: PostmanMockConfig
 ) {
     private val json = Json{
         isLenient = true
@@ -43,9 +43,18 @@ class PostmanAPIClient(
             json.decodeFromString<Postman.CollectionResponse>(responseBody)
         } else {
             when(response.code) {
-                401 -> throw(Exception("Error: Unauthorized - Check your Postman API key"))
+                401 -> throw(PostmanAPIKeyException())
                 else -> throw(Exception("Error: ${response.code} - ${response.message}"))
             }
         }
     }
+
+    /**
+     *
+     */
+    fun updatePostmanAccessKey(newKey: String) {
+        config = config.copy(postmanAccessKey = newKey)
+    }
 }
+
+class PostmanAPIKeyException : Exception("Error: Unauthorized - Check your Postman API key")

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
@@ -57,6 +57,12 @@ class PostmanMockRepo(
     private val mutableEnabledMocks = MutableStateFlow<Map<ApiName, Postman.SavedMock>>(mapOf())
     val enabledMocks = mutableEnabledMocks.asStateFlow()
 
+    /**
+     *
+     */
+    private val mutableFlattenedMockItems = MutableStateFlow<List<Postman.Item>>(emptyList())
+    val flattenedMockItems = mutableFlattenedMockItems.asStateFlow()
+
     //==================================================================
     // Public methods
     //==================================================================
@@ -134,6 +140,10 @@ class PostmanMockRepo(
         try {
             val response = postmanClient.getCollection(collectionId)!!.collection
             mutableMockCollection.emit(response)
+
+            mutableFlattenedMockItems.emit(
+                flattenedItems(response.item).filter { !it.savedMocks.isNullOrEmpty() }
+            )
 
             // Determine available groups from response
             mutableMockGroups.emit(findMockingGroups(response))

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/repo/PostmanMockRepo.kt
@@ -27,6 +27,9 @@ class PostmanMockRepo(
     var mockResponseDelayMs = 0
 
     private val postmanClient = PostmanAPIClient(config)
+    fun updatePostmanAccessKey(newKey: String) {
+        postmanClient.updatePostmanAccessKey(newKey)
+    }
 
     /**
      * Load state for list of all mocks available on Postman.

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
@@ -235,9 +235,12 @@ private fun AvailableMocks(
             style = MaterialTheme.typography.h6
         )
 
+        Text(text = "Currently enabled: ${enabledMocks?.size ?: 0}")
+
         Spacer(modifier = Modifier.height(8.dp))
 
-        // todo left off scroll up and down aren't working?
+
+
 
         //---------------------------------------------------------------
         // Global actions

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -38,6 +39,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun AvailableMocks(
+    modifier: Modifier = Modifier,
     mockRepo: PostmanMockRepo
 ) {
     val mockCollection by mockRepo.mockCollection.collectAsState()
@@ -48,6 +50,7 @@ fun AvailableMocks(
 
     mockCollection?.let { collection ->
         AvailableMocks(
+            modifier = modifier,
             collection = collection,
             enabledMocks = enabledMocks,
             mockResponseDelayMs = mockRepo.mockResponseDelayMs,
@@ -166,7 +169,6 @@ private fun PostmanItem(
 
             // Else show all the mocks available for the given API
             val enabledMock = enabledMocks?.get(item.name)
-            Divider(startIndent = startOffset)
             Spacer(modifier = Modifier.height(8.dp))
             MocksForApi(
                 modifier = Modifier.padding(start = startOffset),
@@ -180,7 +182,6 @@ private fun PostmanItem(
         is Postman.TypedItem.Folder -> {
             // We have a folder of possible items, show the older name and then iterate
             // through all items in the folder.
-            Divider(startIndent = startOffset)
             Text(
                 modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
                 text = typed.name,
@@ -203,6 +204,7 @@ private fun PostmanItem(
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AvailableMocks(
+    modifier: Modifier,
     collection: Postman.Collection,
     enabledMocks: Map<ApiName, Postman.SavedMock>?,
     mockResponseDelayMs: Int,
@@ -219,15 +221,15 @@ private fun AvailableMocks(
     val focusManager = LocalFocusManager.current
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .padding(16.dp)
-            .scrollable(rememberScrollState(), orientation = Orientation.Vertical)
+            .verticalScroll(rememberScrollState())
     ) {
         //---------------------------------------------------------------
         // Collection name
         //---------------------------------------------------------------
         Text(
-            text = collection.info.name,
+            text = "Mocks available for ${collection.info.name}",
             style = MaterialTheme.typography.h6
         )
 
@@ -253,7 +255,6 @@ private fun AvailableMocks(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
-        Divider()
 
         //---------------------------------------------------------------
         // APIs in collection
@@ -268,7 +269,6 @@ private fun AvailableMocks(
                 )
             }
             // Final bottom divider
-            Divider()
         }
     }
 }

--- a/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
+++ b/lib-core/src/main/java/com/steamclock/steamock/lib/ui/AvailableMockComposables.kt
@@ -141,7 +141,7 @@ private fun MocksForApi(
                     if (checked) {
                         onMockSelected(mock)
                     } else {
-                        onMockDeselected
+                        onMockDeselected()
                     }
                 }
             )
@@ -220,6 +220,8 @@ private fun AvailableMocks(
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 
+    // todo delay can input letters which breaks, validate input
+
     Column(
         modifier = modifier
             .padding(16.dp)
@@ -245,7 +247,7 @@ private fun AvailableMocks(
             onDelayUpdated = { delay = it },
             onDelayDone = {
                 onUpdateMockDelayMs(delay)
-                //keyboardController?.hide()
+                keyboardController?.hide()
                 focusManager.clearFocus()
             },
             availableGroups = availableGroups,
@@ -268,7 +270,6 @@ private fun AvailableMocks(
                     onMockChanged = onMockChanged
                 )
             }
-            // Final bottom divider
         }
     }
 }


### PR DESCRIPTION
Fixed up the following issues with the library:
* Mocks can now be correctly deselected
* Added "currently enabled" count for clarity
* Removed "collapsable" content - this was causing big layout exceptions and was more hassle than it was worth
* Removed divider lines... they just didn't look good
* Loading and error states now handled in library
* If API Key is no longer valid, show input that allows manual entry of key

Fixed the following in the sample app:
* Moved out error handling (now in library)
* Request simulator is now populated via a dropdown box using all available APIs in the postman collection; this allows QA to more easily test each API without manually typing each one